### PR TITLE
ci: add workflow to enforce `main` branch protection from non-`develo…

### DIFF
--- a/.github/workflows/enforce_branching.yml
+++ b/.github/workflows/enforce_branching.yml
@@ -1,0 +1,15 @@
+name: "Block PRs to main except from develop"
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  enforce-pr-source:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR source
+        if: github.base_ref == 'main' && github.head_ref != 'develop'
+        run: |
+          echo "PR to main must come from develop!"
+          exit 1


### PR DESCRIPTION
…p` PRs